### PR TITLE
docs(README): fix verifyWebhookSignature example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ npm i graphcms-utils
 ### `verifyWebhookSignature`
 
 ```js
-const { verifyWebhookSignature } = require("graphcms-utils");
+const { verifyWebhookSignature, generateWebhookSignature } = require("graphcms-utils");
 
 const secret = "rCNwyiloY3oJYYkxgpBXaleIiUv5MYlx";
 
 const body = {}; // Typically req.body
-
-const signature = verifyWebhookSignature({ body, secret });
+const signature = generateWebhookSignature({ body, secret });
+const isValid = verifyWebhookSignature({ body, secret, signature });
 ```
 
 ### `generateWebhookSignature`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ const { verifyWebhookSignature, generateWebhookSignature } = require("graphcms-u
 const secret = "rCNwyiloY3oJYYkxgpBXaleIiUv5MYlx";
 
 const body = {}; // Typically req.body
-const signature = generateWebhookSignature({ body, secret });
+const signature = "..."; // Typically req.headers['gcms-signature']
+
+const isValid = verifyWebhookSignature({ body, signature, secret });
 const isValid = verifyWebhookSignature({ body, secret, signature });
 ```
 


### PR DESCRIPTION
We might also just make `verifyWebhookSignature` call `verifyWebhookSignature` if no signature is passed in.